### PR TITLE
Add Pre-heater Status, Fireplace Mode, and Software Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ holding registers
 | 0x14A  | 3-way switch control setpoint       | U_WORD   | %     | 0:low;50:medium;100:high |
 | 0x13D  | RF input voltage                    | U_WORD   | V*100 | steering signal (0-10V)  |
 | 0x13F  | Pre-heater active                   | U_WORD   | -     | 0:off;1:on               |
-| 0x152  | Pre-heater enabled                  | U_WORD   | -     | 0:disabled;1:enabled     |
+| 0x152  | Pre-heater present                  | U_WORD   | -     | 0:absent;1:present       |
 | 0x151  | Fireplace mode                      | U_WORD   | -     | 0:off;1:on               |
 | 0x06E  | Software Version                    | U_WORD   | -     | 20800 = 2.8.0            |

--- a/components/zehnder.yaml
+++ b/components/zehnder.yaml
@@ -236,10 +236,10 @@ binary_sensor:
   device_class: heat
 - platform: modbus_controller
   modbus_controller_id: modbus_device
-  name: "Pre-heater enabled"
+  name: "Pre-heater present"
   address: 0x152
   register_type: holding
-  id: zehnder_pre_heater_enabled
+  id: zehnder_pre_heater_present
 - platform: modbus_controller
   modbus_controller_id: modbus_device
   name: "Fireplace mode"


### PR DESCRIPTION
I've managed to map four more registers:

Pre-heater active (Register 0x13F) (pre-heater state)
Pre-heater present (Register 0x152) (service menu-> pre-heater present -> yes / no) 
Fireplace mode (Register 0x151) (service menu -> balance -> fireplace mode on / off)
Software Version (Register 0x06E) (options -> device type -> sw version )