### PR TITLE
Refactor sensor names and move fan duty to diagnostics

### DIFF
--- a/components/zehnder.yaml
+++ b/components/zehnder.yaml
@@ -329,7 +329,6 @@ sensor:
 - platform: modbus_controller
   modbus_controller_id: modbus_device
   name: "Exhaust fan duty cycle"
-  entity_category: "diagnostic"
   icon: mdi:fan
   register_type: holding
   address: 0x136


### PR DESCRIPTION
- Rename air temperature to temperature to make it consistant with humidity.
- Rename fan flow rate to flow rate since it's a property of the air instead of the fan.
- Move fan duty cycle to diagnostics.