### PR TITLE
Feat: append raw value to unknown to simplify reporting of missing values

### DIFF
--- a/components/zehnder.yaml
+++ b/components/zehnder.yaml
@@ -393,7 +393,7 @@ text_sensor:
           case 10: return std::string("Normal");
           case 20: return std::string("Standby");
           case 42: return std::string("Maintenance Mode");
-          default: return std::string("Unknown");
+          default: return std::string("Unknown (") + std::to_string(value) + ")";
         }
         return x;
   
@@ -410,7 +410,7 @@ text_sensor:
         switch (value) {
           case 0: return std::string("Right");
           case 1: return std::string("Left");
-          default: return std::string("Unknown");
+          default: return std::string("Unknown (") + std::to_string(value) + ")";
         }
         return x;
         
@@ -428,7 +428,7 @@ text_sensor:
           case 0: return std::string("E300 P");
           case 2: return std::string("E300 RF");
           case 4: return std::string("E400 RF");
-          default: return std::string("Unknown");
+          default: return std::string("Unknown (") + std::to_string(value) + ")";
         }
         return x;
   


### PR DESCRIPTION
Simplify the discovery of unmapped text sensors by displaying the raw value when an unknown state is reported.

Previously, unmapped statuses would simply return "Unknown". This change appends the raw integer value to the string (e.g., "Unknown (20)"), making it immediately obvious what the unmapped value is without having to query raw registers, add temporary diagnostic sensors, or check debug logs., example:
<img width="578" height="73" alt="image" src="https://github.com/user-attachments/assets/d2837326-6b46-4833-8074-3f3ec636843d" />

This should make it much easier for less technical users to contribute to the discovery process! :)